### PR TITLE
Update image_selector.py

### DIFF
--- a/Katna/image_selector.py
+++ b/Katna/image_selector.py
@@ -230,9 +230,12 @@ class ImageSelector(object):
             variance_laplacians = self.__get_laplacian_scores(files, n_images)
 
             # Selecting image with low burr(high laplacian) score
-            selected_frame_of_current_cluster = curr_row[np.argmax(variance_laplacians)]
-            filtered_items.append(selected_frame_of_current_cluster)
-
+            try:
+                selected_frame_of_current_cluster = curr_row[np.argmax(variance_laplacians)]
+                filtered_items.append(selected_frame_of_current_cluster)
+            except Exception as e:
+                print(f'skiped cluster {cluster_i} cause {e}')
+                
         return filtered_items
 
     # def __getstate__(self):


### PR DESCRIPTION
When the actually cluster number is smaller than the assigned cluster number, katna will raise an unexpected Exception, which may need to be handled.
```
.pylib/Lib/site-packages/Katna/image_selector.py:171: ConvergenceWarning: Number of distinct clusters (59) found smaller than n_clusters (64). Possibly due to duplicate points in X.
  kmeans = KMeans(n_clusters=self.nb_clusters, random_state=0).fit(all_hists)
Traceback (most recent call last):
  File "1.video_keyframe_extraction.py", line 42, in <module>
    main()
  File "1.video_keyframe_extraction.py", line 37, in main
    writer=diskwriter
  File ".pylib/Lib/site-packages/Katna/decorators.py", line 128, in wrapper
    return decorated(*args, **kwargs)
  File ".pylib/Lib/site-packages/Katna/video.py", line 274, in extract_video_keyframes
    top_frames = self._extract_keyframes_from_video(no_of_frames, file_path)
  File ".pylib/Lib/site-packages/Katna/video.py", line 190, in _extract_keyframes_from_video
    extracted_candidate_frames, no_of_frames
  File ".pylib/Lib/site-packages/Katna/image_selector.py", line 298, in select_best_frames
    filtered_key_frames, files_clusters_index_array
  File ".pylib/Lib/site-packages/Katna/image_selector.py", line 233, in __get_best_images_index_from_each_cluster__
    selected_frame_of_current_cluster = curr_row[np.argmax(variance_laplacians)]
  File "<__array_function__ internals>", line 6, in argmax
  File ".pylib/Lib/site-packages/numpy/core/fromnumeric.py", line 1188, in argmax
    return _wrapfunc(a, 'argmax', axis=axis, out=out)
  File ".pylib/Lib/site-packages/numpy/core/fromnumeric.py", line 55, in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
  File ".pylib/Lib/site-packages/numpy/core/fromnumeric.py", line 44, in _wrapit
    result = getattr(asarray(obj), method)(*args, **kwds)
ValueError: attempt to get argmax of an empty sequence
```